### PR TITLE
automatically build the c library for the rust demo

### DIFF
--- a/car_demo/Cargo.toml
+++ b/car_demo/Cargo.toml
@@ -19,3 +19,7 @@ time = { version = "0.3", features = ["formatting"] }
 
 [build-dependencies]
 bindgen = "0.72"
+cc = "1.0"
+
+[features]
+link-system = []

--- a/car_demo/build.rs
+++ b/car_demo/build.rs
@@ -1,7 +1,16 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
-fn main() {
-    println!("cargo:rerun-if-changed=../libccar.h");
+// build the c library from source
+#[cfg(not(feature = "link-system"))]
+fn build_or_link() {
+    let mut build = cc::Build::new();
+    build.file("../build_libccar.c").include("..");
+    build.compile("ccar");
+}
+
+// link the pre-compiled library
+#[cfg(feature = "link-system")]
+fn build_or_link() {
     println!("cargo:rerun-if-env-changed=LIBCCAR_LIB_DIR");
     println!("cargo:rerun-if-env-changed=LIBCCAR_LINK_NAME");
 
@@ -39,6 +48,12 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", abs.display());
         println!("cargo:rustc-link-lib=dylib=ccar");
     }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=../libccar.h");
+
+    build_or_link();
 
     // Bindgen
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Adds a feature to control if the rust demo links to a pre-compiled library (the old behavior). If the feature is not enabled, the rust build will compile the C code using the cc crate and link to that, making it possible to run the demo without having to manually compile the C code first.